### PR TITLE
fix: Remove fetching:collection listener

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,6 @@ module.exports = (bookshelf, settings) => {
       }
 
       this.on('fetching', skipDeleted.bind(this))
-      this.on('fetching:collection', skipDeleted.bind(this))
     },
 
     /**


### PR DESCRIPTION
We already hook into the Collection fetching event so that causes the query to be modified twice in some cases.