### PR TITLE
fixed error sql when deleted_at had a default value

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,11 +49,13 @@ module.exports = (bookshelf, settings) => {
 
       if (softDelete && !options.withDeleted) {
         options.query
-          .whereNull(`${result(this, 'tableName')}.${settings.field}`)
-          .orWhere(
-            `${result(this, 'tableName')}.${settings.field}`,
-            '0000-00-00 00:00:00'
-          )
+          .andWhere(qb => {
+            qb.whereNull(`${result(this, 'tableName')}.${settings.field}`)
+              .orWhere(
+                `${result(this, 'tableName')}.${settings.field}`,
+                '0000-00-00 00:00:00'
+              );
+          });
       }
     }
   }


### PR DESCRIPTION
When `deleted_at` had a default value as '0000-00-00 00:00:00'
The generated sql was wrong.
This PR fixed this bug.