### PR TITLE
Do not throw an error if a row was soft deleted (#28)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 let Promise = require('bluebird')
 let result = require('lodash.result')
 let merge = require('lodash.merge')
-let isEmpty = require('lodash.isempty')
 
 /**
  * A function that can be used as a plugin for bookshelf
@@ -166,11 +165,12 @@ module.exports = (bookshelf, settings) => {
             return query
               .update(attrs, this.idAttribute)
               .where(this.format(this.attributes))
+              .where(`${result(this, 'tableName')}.${settings.field}`, settings.nullValue)
           })
           .then((resp) => {
             // Check if the caller required a row to be deleted and if
             // events weren't totally disabled
-            if (isEmpty(resp) && options.require) {
+            if (resp === 0 && options.require) {
               throw new this.constructor.NoRowsDeletedError('No Rows Deleted')
             } else if (!settings.events) {
               return

--- a/package-lock.json
+++ b/package-lock.json
@@ -1294,11 +1294,6 @@
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
       "dev": true
     },
-    "lodash.isempty": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
-    },
     "lodash.merge": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "homepage": "https://github.com/estate/bookshelf-paranoia#readme",
   "dependencies": {
     "bluebird": "^3.4.7",
-    "lodash.isempty": "^4.4.0",
     "lodash.merge": "^4.3.5",
     "lodash.result": "^4.3.0"
   },

--- a/test/spec/general.js
+++ b/test/spec/general.js
@@ -112,6 +112,13 @@ lab.experiment('general tests', () => {
       expect(err).to.be.an.error('No Rows Deleted')
     }))
 
+    lab.test('should not throw when required if a row was soft deleted', co.wrap(function * () {
+      yield Comment.forge({ id: 1 }).destroy({ require: true })
+
+      let comment = yield Comment.forge({ id: 1 }).fetch()
+      expect(comment).to.be.null()
+    }))
+
     lab.test('allows for filtered catch', co.wrap(function * () {
       let err = yield Comment.forge({ id: 12345 })
         .destroy({ require: true })


### PR DESCRIPTION
I've noticed that a `NoRowsError` was thrown when `required` was `true`, even though a row was actually soft deleted (#28). This was caused by checking whether the [update response is an empty collection](https://github.com/bsiddiqui/bookshelf-paranoia/blob/master/index.js#L173), but it turns out that Knex returns just `0 ` instead.
Fixing that issue uncovered another bug, as it was possible to delete any row twice, it updated the `deleted_at` column with the current time stamp. This has been tackled as well in this PR.